### PR TITLE
Move all the closed source solutions to a separate file

### DIFF
--- a/CLOSED_SOURCE_SOLUTIONS.md
+++ b/CLOSED_SOURCE_SOLUTIONS.md
@@ -1,0 +1,51 @@
+# Commercial Alternatives
+
+## Central Hub
+
+### Revolv
+
+Was a $300 hub, offering a "lifetime subscription".
+
+Acquired by Nest (Google subsidiary) in October 2014. In April 2016, Nest
+announced that Revolv Hub will cease to operate on May 15, 2016.
+https://en.wikipedia.org/wiki/Nest_Labs#Intentional_disabling_of_hardware_devices
+
+
+### SmartThings
+
+* 2012-08-23 [KickStarter campaign](https://www.kickstarter.com/projects/smartthings/smartthings-make-your-world-smarter)
+  $1.2M/$250K
+* 2014-08-14 [Acquired by Samsung](http://www.samsung.com/us/news/23607)
+  refs: [(1)](http://linuxgizmos.com/samsung-smartthings-pickup-could-mean-new-role-for-tizen/)
+* 2015-01-05 [Hub 2 runs Linux](http://blog.smartthings.com/news/smartthings-updates/new-hub-sensors-optional-services-integrations/)
+  refs: [(1)](http://linuxgizmos.com/gen-2-smartthings-hub-migrates-to-linux/)
+
+Uses Groovy language for (custom) components.
+
+* [SmartThings open-source components](https://github.com/SmartThingsCommunity/SmartThingsPublic) Site: http://docs.smartthings.com, Forks: 27667, Language: Groovy
+
+
+### Vera
+
+Since at least 2008.
+
+Uses Lua, open development support, community ecosystem.
+
+
+### Wink
+
+* Founded in 2014 as a spin-off from invention incubator Quirky.
+* After Quirky went through bankruptcy proceedings, it sold Wink to Flex in 2015.
+* In July 2017, Flex sold Wink to i.am+ for $38.7M.
+
+## Home Automation Services
+
+### Voice/Personal Assistants
+
+Previously, government and mob had to break into your house to install bugs.
+Now you can pay a small amount of money and install yourself bugs which allow
+3rd parties to eavesdrop on you.
+
+* Apple Siri
+* Amazon Alexa
+* Google Assistant

--- a/README.md
+++ b/README.md
@@ -27,56 +27,9 @@ Related awesome lists:
 * [Awesome Home Assistant](https://github.com/frenck/awesome-home-assistant)
 
 
-## Notable Commercial Systems
-
-### Revolv
-
-Was a $300 hub, offering a "lifetime subscription".
-
-Acquired by Nest (Google subsidiary) in October 2014. In April 2016, Nest
-announced that Revolv Hub will cease to operate on May 15, 2016.
-https://en.wikipedia.org/wiki/Nest_Labs#Intentional_disabling_of_hardware_devices
-
-
-### SmartThings
-
-* 2012-08-23 [KickStarter campaign](https://www.kickstarter.com/projects/smartthings/smartthings-make-your-world-smarter)
-  $1.2M/$250K
-* 2014-08-14 [Acquired by Samsung](http://www.samsung.com/us/news/23607)
-  refs: [(1)](http://linuxgizmos.com/samsung-smartthings-pickup-could-mean-new-role-for-tizen/)
-* 2015-01-05 [Hub 2 runs Linux](http://blog.smartthings.com/news/smartthings-updates/new-hub-sensors-optional-services-integrations/)
-  refs: [(1)](http://linuxgizmos.com/gen-2-smartthings-hub-migrates-to-linux/)
-
-Uses Groovy language for (custom) components.
-
-* [SmartThings open-source components](https://github.com/SmartThingsCommunity/SmartThingsPublic) Site: http://docs.smartthings.com, Forks: 27667, Language: Groovy
-
-
-### Vera
-
-Since at least 2008.
-
-Uses Lua, open development support, community ecosystem.
-
-
-### Wink
-
-* Founded in 2014 as a spin-off from invention incubator Quirky.
-* After Quirky went through bankruptcy proceedings, it sold Wink to Flex in 2015.
-* In July 2017, Flex sold Wink to i.am+ for $38.7M.
-
-
 ## Home Automation Services
 
 ### Voice/Personal Assistants
-
-Previously, government and mob had to break into your house to install bugs.
-Now you can pay a small amount of money and install yourself bugs which allow
-3rd parties to eavesdrop on you.
-
-* Apple Siri
-* Amazon Alexa
-* Google Assistant
 
 OpenSource services promising no eavesdropping (please keep in mind that for
 some of these projects, "OpenSource" is just a marketing bait):


### PR DESCRIPTION
If the lists is focused on open source projects, why put commercial systems at all?
Everything in the list is meant to be awesome, right?

What's more everyone knows about Alexa & co, no curation needed here.

More details in #8 